### PR TITLE
feat: 트렌드 분석 상세 페이지 구조 및 목데이터 연동

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@tanstack/react-query": "^5.17.19",
         "axios": "^1.6.7",
         "clsx": "^2.1.0",
+        "d3": "^7.9.0",
         "date-fns": "^3.3.1",
         "framer-motion": "^12.26.1",
         "lucide-react": "^0.321.0",
@@ -28,6 +29,7 @@
         "zustand": "^4.5.0"
       },
       "devDependencies": {
+        "@types/d3": "^7.4.3",
         "@types/node": "^20.11.16",
         "@types/react": "^18.2.52",
         "@types/react-dom": "^18.2.18",
@@ -594,10 +596,76 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/d3": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
+      "integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/d3-axis": "*",
+        "@types/d3-brush": "*",
+        "@types/d3-chord": "*",
+        "@types/d3-color": "*",
+        "@types/d3-contour": "*",
+        "@types/d3-delaunay": "*",
+        "@types/d3-dispatch": "*",
+        "@types/d3-drag": "*",
+        "@types/d3-dsv": "*",
+        "@types/d3-ease": "*",
+        "@types/d3-fetch": "*",
+        "@types/d3-force": "*",
+        "@types/d3-format": "*",
+        "@types/d3-geo": "*",
+        "@types/d3-hierarchy": "*",
+        "@types/d3-interpolate": "*",
+        "@types/d3-path": "*",
+        "@types/d3-polygon": "*",
+        "@types/d3-quadtree": "*",
+        "@types/d3-random": "*",
+        "@types/d3-scale": "*",
+        "@types/d3-scale-chromatic": "*",
+        "@types/d3-selection": "*",
+        "@types/d3-shape": "*",
+        "@types/d3-time": "*",
+        "@types/d3-time-format": "*",
+        "@types/d3-timer": "*",
+        "@types/d3-transition": "*",
+        "@types/d3-zoom": "*"
+      }
+    },
     "node_modules/@types/d3-array": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
       "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-axis": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz",
+      "integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-brush": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
+      "integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-chord": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.6.tgz",
+      "integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/d3-color": {
@@ -606,10 +674,93 @@
       "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
       "license": "MIT"
     },
+    "node_modules/@types/d3-contour": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
+      "integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-dispatch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
+      "integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-dsv": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
+      "integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/d3-ease": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
       "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-fetch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
+      "integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-dsv": "*"
+      }
+    },
+    "node_modules/@types/d3-force": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
+      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-format": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
+      "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-geo": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
+      "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-hierarchy": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
+      "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/d3-interpolate": {
@@ -627,6 +778,27 @@
       "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
       "license": "MIT"
     },
+    "node_modules/@types/d3-polygon": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
+      "integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-quadtree": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
+      "integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-random": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.3.tgz",
+      "integrity": "sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/d3-scale": {
       "version": "4.0.9",
       "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
@@ -635,6 +807,20 @@
       "dependencies": {
         "@types/d3-time": "*"
       }
+    },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/d3-shape": {
       "version": "3.1.7",
@@ -651,10 +837,45 @@
       "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
       "license": "MIT"
     },
+    "node_modules/@types/d3-time-format": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
+      "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/d3-timer": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json5": {
@@ -1872,6 +2093,47 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
+    "node_modules/d3": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "3",
+        "d3-axis": "3",
+        "d3-brush": "3",
+        "d3-chord": "3",
+        "d3-color": "3",
+        "d3-contour": "4",
+        "d3-delaunay": "6",
+        "d3-dispatch": "3",
+        "d3-drag": "3",
+        "d3-dsv": "3",
+        "d3-ease": "3",
+        "d3-fetch": "3",
+        "d3-force": "3",
+        "d3-format": "3",
+        "d3-geo": "3",
+        "d3-hierarchy": "3",
+        "d3-interpolate": "3",
+        "d3-path": "3",
+        "d3-polygon": "3",
+        "d3-quadtree": "3",
+        "d3-random": "3",
+        "d3-scale": "4",
+        "d3-scale-chromatic": "3",
+        "d3-selection": "3",
+        "d3-shape": "3",
+        "d3-time": "3",
+        "d3-time-format": "4",
+        "d3-timer": "3",
+        "d3-transition": "3",
+        "d3-zoom": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-array": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
@@ -1879,6 +2141,43 @@
       "license": "ISC",
       "dependencies": {
         "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-axis": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-brush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "3",
+        "d3-transition": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-chord": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "1 - 3"
       },
       "engines": {
         "node": ">=12"
@@ -1893,6 +2192,86 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-contour": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "7",
+        "iconv-lite": "0.6",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json.js",
+        "csv2tsv": "bin/dsv2dsv.js",
+        "dsv2dsv": "bin/dsv2dsv.js",
+        "dsv2json": "bin/dsv2json.js",
+        "json2csv": "bin/json2dsv.js",
+        "json2dsv": "bin/json2dsv.js",
+        "json2tsv": "bin/json2dsv.js",
+        "tsv2csv": "bin/dsv2dsv.js",
+        "tsv2json": "bin/dsv2json.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/d3-ease": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
@@ -1902,10 +2281,57 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dsv": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-format": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
       "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -1932,6 +2358,33 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-polygon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-scale": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
@@ -1944,6 +2397,28 @@
         "d3-time": "2.1.1 - 3",
         "d3-time-format": "2 - 4"
       },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
       "engines": {
         "node": ">=12"
       }
@@ -1989,6 +2464,41 @@
       "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
       "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
       "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
       "engines": {
         "node": ">=12"
       }
@@ -2129,6 +2639,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delaunator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.1.tgz",
+      "integrity": "sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==",
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
       }
     },
     "node_modules/delayed-stream": {
@@ -3494,6 +4013,18 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ignore": {
@@ -5626,6 +6157,12 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/robust-predicates": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
+      "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==",
+      "license": "Unlicense"
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -5649,6 +6186,12 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
+    },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/safe-array-concat": {
       "version": "1.1.3",
@@ -5704,6 +6247,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
     },
     "node_modules/scheduler": {
       "version": "0.23.2",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@tanstack/react-query": "^5.17.19",
     "axios": "^1.6.7",
     "clsx": "^2.1.0",
+    "d3": "^7.9.0",
     "date-fns": "^3.3.1",
     "framer-motion": "^12.26.1",
     "lucide-react": "^0.321.0",
@@ -32,6 +33,7 @@
     "zustand": "^4.5.0"
   },
   "devDependencies": {
+    "@types/d3": "^7.4.3",
     "@types/node": "^20.11.16",
     "@types/react": "^18.2.52",
     "@types/react-dom": "^18.2.18",

--- a/src/app/trend-analysis/[category]/page.tsx
+++ b/src/app/trend-analysis/[category]/page.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useParams } from 'next/navigation';
+import { getTrendDataByCategory } from '@/services/trendService';
+import { TrendData } from '@/types/trend';
+import ForceGraph from '@/components/trend-analysis/ForceGraph';
+
+export default function CategoryDetailPage() {
+  const params = useParams();
+  const category = params.category as string;
+
+  const [data, setData] = useState<TrendData | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const loadData = async () => {
+      try {
+        setLoading(true);
+        const result = await getTrendDataByCategory(category);
+        setData(result);
+      } catch (error) {
+        console.error("데이터 로드 실패:", error);
+      } finally {
+        setLoading(false);
+      }
+    };
+    loadData();
+  }, [category]);
+
+  if (loading) return <div className="text-white p-10">트렌드 데이터를 분석 중입니다...</div>;
+  if (!data) return <div className="text-white p-10">데이터를 찾을 수 없습니다.</div>;
+
+  return (
+    <main className="min-h-screen bg-[#1A1B1E] text-white p-6">
+       <h1 style={{ color: data.color }}>{data.name} 생태계 맵</h1>
+       <div className="mt-8 bg-[#25262B] rounded-2xl overflow-hidden">
+         <ForceGraph data={data} themeColor={data.color} />
+       </div>
+    </main>
+  );
+}

--- a/src/app/trend-analysis/page.tsx
+++ b/src/app/trend-analysis/page.tsx
@@ -1,0 +1,74 @@
+// app/trend-analysis/page.tsx
+import Link from 'next/link';
+
+const CATEGORIES = [
+  { 
+    id: 'frontend', 
+    name: 'Frontend', 
+    description: 'React, Next.js 등 현대 웹 인터페이스 및 클라이언트 기술', 
+    color: '#1C89AD' 
+  },
+  { 
+    id: 'backend', 
+    name: 'Backend', 
+    description: '서버 아키텍처, 분산 시스템 및 데이터베이스 설계', 
+    color: '#4CAF50' 
+  },
+  { 
+    id: 'ai-data', 
+    name: 'AI & Data', 
+    description: 'LLM, MLOps, 빅데이터 처리 및 인공지능 모델링', 
+    color: '#FF9800' 
+  },
+  { 
+    id: 'devops', 
+    name: 'DevOps', 
+    description: '클라우드 인프라, 컨테이너화 및 CI/CD 자동화', 
+    color: '#2496ED' 
+  },
+  { 
+    id: 'embedding', 
+    name: 'Embedded', 
+    description: '펌웨어 개발, RTOS 및 하드웨어 최적화 제어', 
+    color: '#FFEB3B' 
+  },
+  { 
+    id: 'game', 
+    name: 'Game Dev', 
+    description: '게임 엔진, 실시간 그래픽스 및 인터랙티브 콘텐츠', 
+    color: '#E91E63' 
+  },
+  { 
+    id: 'security', 
+    name: 'Security', 
+    description: '네트워크 보안, 취약점 분석 및 암호학 시스템', 
+    color: '#9C27B0' 
+  },
+];
+
+export default function TrendAnalysisMain() {
+  return (
+    <main className="min-h-screen bg-[#1A1B1E] text-white py-20 px-6">
+      <div className="max-w-5xl mx-auto text-center">
+        {/* 히어로 섹션 */}
+        <h1 className="text-5xl font-extrabold mb-6">IT 트렌드 분석 시스템</h1>
+        <p className="text-[#9FA0A8] text-xl mb-12">
+          최신 기술 생태계의 연관 관계를 한눈에 파악하세요. <br/>
+          탐색하고 싶은 카테고리를 아래에서 선택하십시오.
+        </p>
+
+        {/* 카테고리 선택 카드 */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mt-16">
+          {CATEGORIES.map((cat) => (
+            <Link key={cat.id} href={`/trend-analysis/${cat.id}`}>
+              <div className="p-8 rounded-2xl bg-[#25262B] border border-white/10 hover:border-white/30 transition-all cursor-pointer group text-left">
+                <h3 className="text-2xl font-bold mb-2" style={{ color: cat.color }}>{cat.name}</h3>
+                <p className="text-[#9FA0A8]">{cat.description}</p>
+              </div>
+            </Link>
+          ))}
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/trend/page.tsx
+++ b/src/app/trend/page.tsx
@@ -1,7 +1,0 @@
-export default function TrendPage() {
-    return (
-        <div className="flex items-center justify-center min-h-screen">
-            <h1 className="text-3xl font-bold">트렌드 분석 페이지 (준비 중)</h1>
-        </div>
-    );
-}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -16,7 +16,7 @@ export default function Navbar() {
     // 마이페이지를 메뉴 리스트에서 제거
     const navItems = [
         { name: '홈 피드', href: '/' },
-        { name: '트렌드 분석', href: '/trend' },
+        { name: '트렌드 분석', href: '/trend-analysis' },
         { name: '채용 지도', href: '/map' },
         { name: 'AI 면접', href: '/ai-interview' },
     ];

--- a/src/components/trend-analysis/CategoryCard.tsx
+++ b/src/components/trend-analysis/CategoryCard.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import Link from 'next/link';
+
+interface CategoryCardProps {
+    id: string;
+    name: string;
+    color: string;
+    }
+
+export default function CategoryCard({ id, name, color }: CategoryCardProps) {
+    return (
+        <div className="flex flex-col items-center group">
+            {/* 노드 그래픽 구역: 나중에 D3.js 미니 버전으로 교체 가능 */}
+            <div className="relative w-56 h-56 flex items-center justify-center mb-6 transition-transform duration-500 group-hover:scale-110">
+                <svg viewBox="0 0 100 100" className="w-full h-full">
+                {/* 디자인 초안 느낌의 연결선과 원들 */}
+                <line x1="50" y1="50" x2="20" y2="30" stroke={color} strokeWidth="1.5" className="opacity-40" />
+                <line x1="50" y1="50" x2="80" y2="40" stroke={color} strokeWidth="1.5" className="opacity-40" />
+                <line x1="50" y1="50" x2="45" y2="85" stroke={color} strokeWidth="1.5" className="opacity-40" />
+                <circle cx="50" cy="50" r="14" fill={color} className="shadow-lg" />
+                <circle cx="20" cy="30" r="9" fill={color} className="opacity-80" />
+                <circle cx="80" cy="40" r="7" fill={color} className="opacity-60" />
+                <circle cx="45" cy="85" r="6" fill={color} className="opacity-50" />
+                
+                {/* 호버 시 퍼지는 효과 */}
+                <circle cx="50" cy="50" r="18" fill="transparent" stroke={color} strokeWidth="1" className="opacity-0 group-hover:opacity-40 animate-ping" />
+                </svg>
+            </div>
+
+            {/* 버튼 스타일 UI */}
+            <Link 
+                href={`/trend-analysis/${id}`}
+                className="px-8 py-2.5 rounded-full border text-sm font-bold transition-all hover:bg-white/5"
+                style={{ borderColor: `${color}66`, color: color }}
+            >
+                {name} &gt;
+            </Link>
+        </div>
+    );
+}

--- a/src/components/trend-analysis/CategoryGrid.tsx
+++ b/src/components/trend-analysis/CategoryGrid.tsx
@@ -1,0 +1,26 @@
+import CategoryCard from './CategoryCard';
+
+const CATEGORIES = [
+    { id: 'frontend', name: 'Frontend', color: '#1C89AD' },
+    { id: 'backend', name: 'Backend', color: '#1A5D3B' },
+    { id: 'ai-data', name: 'AI & Data', color: '#5D2E7A' },
+    { id: 'devops', name: 'DevOps', color: '#9A6B2D' },
+    { id: 'embedding', name: 'Embedding', color: '#8B2E3A' },
+    { id: 'game', name: 'Game', color: '#6A7A2E' },
+    { id: 'security', name: 'Security', color: '#3A4A5A' },
+    ];
+
+    export default function CategoryGrid() {
+    return (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-x-8 gap-y-16 place-items-center">
+        {CATEGORIES.map((category) => (
+            <CategoryCard 
+            key={category.id} 
+            name={category.name} 
+            color={category.color} 
+            id={category.id}
+            />
+        ))}
+        </div>
+    );
+}

--- a/src/components/trend-analysis/ForceGraph.tsx
+++ b/src/components/trend-analysis/ForceGraph.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import * as d3 from 'd3';
+
+export default function ForceGraph({ data, themeColor }: { data: any, themeColor: string }) {
+  const svgRef = useRef<SVGSVGElement>(null);
+
+  useEffect(() => {
+    if (!svgRef.current || !data) return;
+
+    const width = svgRef.current.clientWidth || 800;
+    const height = 600;
+
+    const svg = d3.select(svgRef.current)
+      .attr('viewBox', [0, 0, width, height] as any);
+    
+    svg.selectAll('*').remove(); // 재렌더링 시 초기화
+
+    const nodes = data.nodes.map((d: any) => ({ ...d }));
+    const links = data.links.map((d: any) => ({ ...d }));
+
+    // 1. 시뮬레이션 설정
+    const simulation = d3.forceSimulation(nodes)
+      .force('link', d3.forceLink(links).id((d: any) => d.id).distance(120))
+      .force('charge', d3.forceManyBody().strength(-300))
+      .force('center', d3.forceCenter(width / 2, height / 2));
+
+    // 2. 연결선 그리기
+    const link = svg.append('g')
+      .attr('stroke', '#9FA0A8')
+      .attr('stroke-opacity', 0.3)
+      .selectAll('line')
+      .data(links)
+      .join('line')
+      .attr('stroke-width', 1.5);
+
+    // 3. 노드 그룹 만들기 (원 + 텍스트)
+    const node = svg.append('g')
+      .selectAll('g')
+      .data(nodes)
+      .join('g')
+      .call(drag(simulation) as any);
+
+    // 노드 원 (디자인 초안의 색감 적용)
+    node.append('circle')
+      .attr('r', (d: any) => (d.group === 1 ? 18 : 12))
+      .attr('fill', (d: any) => (d.group === 1 ? themeColor : '#25262B'))
+      .attr('stroke', themeColor)
+      .attr('stroke-width', 2);
+
+    // 노드 텍스트
+    node.append('text')
+      .text((d: any) => d.id)
+      .attr('x', 0)
+      .attr('y', (d: any) => (d.group === 1 ? 30 : 25))
+      .attr('text-anchor', 'middle')
+      .attr('fill', '#fff')
+      .attr('font-size', '12px')
+      .style('pointer-events', 'none');
+
+    // 4. 시뮬레이션 프레임 업데이트
+    simulation.on('tick', () => {
+      link
+        .attr('x1', (d: any) => d.source.x)
+        .attr('y1', (d: any) => d.source.y)
+        .attr('x2', (d: any) => d.target.x)
+        .attr('y2', (d: any) => d.target.y);
+
+      node.attr('transform', (d: any) => `translate(${d.x},${d.y})`);
+    });
+
+    // 🛠️ Sticky Drag 기능 (레퍼런스 핵심 로직)
+    function drag(sim: d3.Simulation<any, undefined>) {
+      function dragstarted(event: any) {
+        if (!event.active) sim.alphaTarget(0.3).restart();
+        event.subject.fx = event.subject.x;
+        event.subject.fy = event.subject.y;
+      }
+
+      function dragged(event: any) {
+        event.subject.fx = event.x;
+        event.subject.fy = event.y;
+      }
+
+      function dragended(event: any) {
+        if (!event.active) sim.alphaTarget(0);
+        // fx, fy를 null로 만들지 않음으로써 그 자리에 고정(Sticky) 시킵니다.
+      }
+
+      return d3.drag()
+        .on('start', dragstarted)
+        .on('drag', dragged)
+        .on('end', dragended);
+    }
+  }, [data, themeColor]);
+
+  return <svg ref={svgRef} className="w-full h-[600px] cursor-move" />;
+}

--- a/src/constants/mockTrends.ts
+++ b/src/constants/mockTrends.ts
@@ -1,0 +1,116 @@
+import { CategoryInfoMap } from '@/types/trend';
+
+export const CATEGORY_INFO: CategoryInfoMap = {
+  frontend: {
+    name: 'Frontend',
+    color: '#1C89AD',
+    nodes: [
+      { id: 'Frontend', group: 1 },
+      { id: 'React', group: 2 }, { id: 'Next.js', group: 2 }, { id: 'Vue', group: 2 },
+      { id: 'Tailwind', group: 3 }, { id: 'TypeScript', group: 3 }, { id: 'Three.js', group: 3 },
+      { id: 'Redux', group: 3 }, { id: 'Zustand', group: 3 }, { id: 'SWR', group: 3 }
+    ],
+    links: [
+      { source: 'Frontend', target: 'React' }, { source: 'Frontend', target: 'Next.js' },
+      { source: 'Frontend', target: 'Vue' }, { source: 'React', target: 'Next.js' },
+      { source: 'React', target: 'TypeScript' }, { source: 'Next.js', target: 'Tailwind' },
+      { source: 'React', target: 'Redux' }, { source: 'React', target: 'Zustand' }
+    ]
+  },
+  backend: {
+    name: 'Backend',
+    color: '#4CAF50',
+    nodes: [
+      { id: 'Backend', group: 1 },
+      { id: 'Spring Boot', group: 2 }, { id: 'Node.js', group: 2 }, { id: 'Go', group: 2 },
+      { id: 'PostgreSQL', group: 3 }, { id: 'Redis', group: 3 }, { id: 'Kafka', group: 3 },
+      { id: 'Docker', group: 3 }, { id: 'GraphQL', group: 3 }, { id: 'gRPC', group: 3 }
+    ],
+    links: [
+      { source: 'Backend', target: 'Spring Boot' }, { source: 'Backend', target: 'Node.js' },
+      { source: 'Backend', target: 'Go' }, { source: 'Spring Boot', target: 'PostgreSQL' },
+      { source: 'Node.js', target: 'Redis' }, { source: 'Go', target: 'Kafka' },
+      { source: 'Backend', target: 'GraphQL' }, { source: 'Go', target: 'gRPC' }
+    ]
+  },
+  'ai-data': {
+    name: 'AI & Data',
+    color: '#FF9800',
+    nodes: [
+      { id: 'AI & Data', group: 1 },
+      { id: 'PyTorch', group: 2 }, { id: 'LLM', group: 2 }, { id: 'MLOps', group: 2 },
+      { id: 'LangChain', group: 3 }, { id: 'HuggingFace', group: 3 }, { id: 'Vector DB', group: 3 },
+      { id: 'TensorFlow', group: 3 }, { id: 'Pandas', group: 3 }, { id: 'Spark', group: 3 }
+    ],
+    links: [
+      { source: 'AI & Data', target: 'PyTorch' }, { source: 'AI & Data', target: 'LLM' },
+      { source: 'LLM', target: 'LangChain' }, { source: 'LLM', target: 'Vector DB' },
+      { source: 'PyTorch', target: 'HuggingFace' }, { source: 'LLM', target: 'MLOps' },
+      { source: 'AI & Data', target: 'Spark' }
+    ]
+  },
+  devops: {
+    name: 'DevOps',
+    color: '#2496ED',
+    nodes: [
+      { id: 'DevOps', group: 1 },
+      { id: 'Docker', group: 2 }, { id: 'Kubernetes', group: 2 }, { id: 'Terraform', group: 2 },
+      { id: 'GitHub Actions', group: 3 }, { id: 'Prometheus', group: 3 }, { id: 'AWS', group: 3 },
+      { id: 'Grafana', group: 3 }, { id: 'Ansible', group: 3 }, { id: 'ArgoCD', group: 3 }
+    ],
+    links: [
+      { source: 'DevOps', target: 'Docker' }, { source: 'Docker', target: 'Kubernetes' },
+      { source: 'DevOps', target: 'Terraform' }, { source: 'Kubernetes', target: 'Prometheus' },
+      { source: 'DevOps', target: 'GitHub Actions' }, { source: 'Terraform', target: 'AWS' },
+      { source: 'Prometheus', target: 'Grafana' }, { source: 'Kubernetes', target: 'ArgoCD' }
+    ]
+  },
+  embedding: {
+    name: 'Embedded',
+    color: '#FFEB3B',
+    nodes: [
+      { id: 'Embedded', group: 1 },
+      { id: 'C/C++', group: 2 }, { id: 'RTOS', group: 2 }, { id: 'Firmware', group: 2 },
+      { id: 'Raspberry Pi', group: 3 }, { id: 'ESP32', group: 3 }, { id: 'Edge AI', group: 3 },
+      { id: 'Arduino', group: 3 }, { id: 'FreeRTOS', group: 3 }, { id: 'ARM', group: 3 }
+    ],
+    links: [
+      { source: 'Embedded', target: 'C/C++' }, { source: 'Embedded', target: 'RTOS' },
+      { source: 'C/C++', target: 'Firmware' }, { source: 'RTOS', target: 'ESP32' },
+      { source: 'Embedded', target: 'Raspberry Pi' }, { source: 'Firmware', target: 'Edge AI' },
+      { source: 'RTOS', target: 'FreeRTOS' }
+    ]
+  },
+  game: {
+    name: 'Game Dev',
+    color: '#E91E63',
+    nodes: [
+      { id: 'Game Dev', group: 1 },
+      { id: 'Unreal Engine', group: 2 }, { id: 'Unity', group: 2 }, { id: 'Godot', group: 2 },
+      { id: 'C#', group: 3 }, { id: 'C++', group: 3 }, { id: 'Shaders', group: 3 },
+      { id: 'DirectX', group: 3 }, { id: 'Vulkan', group: 3 }, { id: 'Blender', group: 3 }
+    ],
+    links: [
+      { source: 'Game Dev', target: 'Unreal Engine' }, { source: 'Game Dev', target: 'Unity' },
+      { source: 'Unity', target: 'C#' }, { source: 'Unreal Engine', target: 'C++' },
+      { source: 'Unreal Engine', target: 'Shaders' }, { source: 'Game Dev', target: 'Godot' },
+      { source: 'Shaders', target: 'Vulkan' }
+    ]
+  },
+  security: {
+    name: 'Security',
+    color: '#9C27B0',
+    nodes: [
+      { id: 'Security', group: 1 },
+      { id: 'Pentesting', group: 2 }, { id: 'Cryptography', group: 2 }, { id: 'Zero Trust', group: 2 },
+      { id: 'Kali Linux', group: 3 }, { id: 'OAuth2', group: 3 }, { id: 'SIEM', group: 3 },
+      { id: 'Wireshark', group: 3 }, { id: 'Burp Suite', group: 3 }, { id: 'Metasploit', group: 3 }
+    ],
+    links: [
+      { source: 'Security', target: 'Pentesting' }, { source: 'Security', target: 'Cryptography' },
+      { source: 'Pentesting', target: 'Kali Linux' }, { source: 'Security', target: 'Zero Trust' },
+      { source: 'Zero Trust', target: 'OAuth2' }, { source: 'Security', target: 'SIEM' },
+      { source: 'Pentesting', target: 'Burp Suite' }
+    ]
+  },
+};

--- a/src/services/trendService.ts
+++ b/src/services/trendService.ts
@@ -1,0 +1,22 @@
+// src/services/trendService.ts
+import api from '@/lib/api';
+import { CATEGORY_INFO } from '@/constants/mockTrends';
+import { TrendData } from '@/types/trend';
+
+// true면 목데이터 사용, false면 실제 API 호출
+const USE_MOCK = true; 
+
+export const getTrendDataByCategory = async (category: string): Promise<TrendData> => {
+  if (USE_MOCK) {
+    // 목데이터 반환 (0.5초 지연으로 네트워크 느낌만 냄)
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        resolve(CATEGORY_INFO[category] || CATEGORY_INFO.frontend);
+      }, 500);
+    });
+  }
+
+  // 실제 백엔드 연동 시 (팀장님이 만든 axios 인스턴스 사용)
+  const response = await api.get<TrendData>(`/trends/${category}/`);
+  return response.data;
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -109,3 +109,7 @@ export interface AuthResponse {
   refresh: string;
   user: User;
 }
+
+
+// src/types/trend.ts
+export * from './trend';

--- a/src/types/trend.ts
+++ b/src/types/trend.ts
@@ -1,0 +1,23 @@
+// src/types/trend.ts
+
+export interface TechNode {
+  id: string;    // 노드 이름 (예: 'React')
+  group: number; // 그룹 번호 (중심부, 주변부 구분 등)
+  value?: number; // (선택) 노드의 중요도나 크기
+}
+
+export interface TechLink {
+  source: string; // 시작 노드 ID
+  target: string; // 끝 노드 ID
+  value?: number; // (선택) 선의 두께나 관계의 강도
+}
+
+export interface TrendData {
+  name: string;
+  color: string;
+  nodes: TechNode[];
+  links: TechLink[];
+}
+
+// 카테고리 전체 목록 타입
+export type CategoryInfoMap = Record<string, TrendData>;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
+    "baseUrl": ".",
     "skipLibCheck": true,
     "strict": true,
     "noEmit": true,


### PR DESCRIPTION
## 📢 기능 설명
1. 주요 작업 내용
카테고리별 동적 라우팅 구현: [category]/page.tsx를 통해 7개 기술 스택(Frontend, Backend, AI&Data 등)의 상세 그래프 페이지 구조를 잡았습니다.

데이터 계층 분리 (Decoupled Architecture):
UI 로직과 데이터를 분리하여 유지보수성을 높였습니다.
Types: 기술 노드 및 링크 데이터의 규격 정의 (TrendData, TechNode 등).
Constants: 백엔드 연동 전까지 사용할 7개 카테고리의 상세 목데이터(Mock Data) 구축.

서비스 레이어 도입:
팀 공통 api.ts (Axios) 인스턴스를 활용하는 trendService를 구축했습니다.
USE_MOCK 플래그를 통해 백엔드 API 완성 시 코드 수정 없이 즉시 전환이 가능한 구조를 만들었습니다.

비동기 데이터 페칭: useEffect와 상태 관리를 통해 실제 API와 통신하는 것과 동일한 데이터 흐름을 구현했습니다.

## 변경된 폴더구조
<img width="955" height="548" alt="image" src="https://github.com/user-attachments/assets/bfff6d5d-e8d0-4282-83b7-fbb565b4c788" />

## 향후 진행 계획 (To-do)
- [ ] 데이터 로딩 시 사용자 경험 개선을 위한 Loading Skeleton 또는 Spinner 추가
- [ ] 그래프 내 노드 클릭 시 해당 기술의 상세 정보를 보여주는 Side Drawer/Modal 구현
- [ ] 실제 백엔드 API 엔드포인트 연결 및 USE_MOCK 전환 테스트

## 연결된 issue
close #8 


## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?