### PR TITLE
feat: 비로그인 즐겨찾기(트렌드분석, 채용지도)/AI 체험 시 로그인 모달 구현

### DIFF
--- a/src/app/ai-interview/onboarding/page.tsx
+++ b/src/app/ai-interview/onboarding/page.tsx
@@ -2,8 +2,10 @@
 
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
+import { useSession } from 'next-auth/react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { ChevronRight, ChevronLeft, Building2, PieChart, Sparkles, ClipboardCheck, Rocket } from 'lucide-react';
+import LoginModal from '@/components/LoginModal';
 
 const ONBOARDING_STEPS = [
     {
@@ -39,6 +41,8 @@ const ONBOARDING_STEPS = [
 export default function AIInterviewOnboarding() {
     const [[currentStep, direction], setStep] = useState([0, 0]);
     const router = useRouter();
+    const { data: session, status } = useSession();
+    const [isLoginModalOpen, setIsLoginModalOpen] = useState(false);
 
     const variants = {
         initial: (direction: number) => ({
@@ -59,6 +63,11 @@ export default function AIInterviewOnboarding() {
         if (currentStep < ONBOARDING_STEPS.length - 1) {
         setStep([currentStep + 1, 1]);
         } else {
+        // 마지막 단계: 로그인된 경우에만 체험 진입, 비로그인이면 로그인 모달 노출
+        if (status !== 'authenticated' || !session) {
+            setIsLoginModalOpen(true);
+            return;
+        }
         localStorage.setItem('seenAIOnboarding', 'true'); // 루프 방지 기록
         router.push('/ai-interview');
         }
@@ -122,6 +131,7 @@ export default function AIInterviewOnboarding() {
             </button>
             </div>
         </div>
+        <LoginModal isOpen={isLoginModalOpen} onClose={() => setIsLoginModalOpen(false)} />
         </div>
     );
 }

--- a/src/app/map/page.tsx
+++ b/src/app/map/page.tsx
@@ -5,8 +5,12 @@ import { Search, Star } from "lucide-react";
 import { mockCompanies, getCompaniesByArea } from "./_models/companies.mock";
 import type { Company, LocationArea } from "./_models/companies.types";
 import { useCompanyFavoritesStore } from "@/store/companyFavoritesStore";
+import { useSession } from "next-auth/react";
+import LoginModal from "@/components/LoginModal";
 
 export default function JobMapPage() {
+  const { data: session } = useSession();
+  const [isLoginModalOpen, setIsLoginModalOpen] = useState(false);
   const [selectedArea, setSelectedArea] = useState<LocationArea>("강남");
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedCompany, setSelectedCompany] = useState<Company | null>(null);
@@ -52,6 +56,10 @@ export default function JobMapPage() {
   // 즐겨찾기 토글
   const handleToggleFavorite = (company: Company, e?: React.MouseEvent) => {
     if (e) e.stopPropagation();
+    if (!session) {
+      setIsLoginModalOpen(true);
+      return;
+    }
     toggleFavorite(company.id);
     // store 업데이트로 인해 자동으로 리렌더링됨
   };
@@ -328,6 +336,9 @@ export default function JobMapPage() {
           </div>
         )}
       </main>
+
+      {/* 로그인 모달 */}
+      <LoginModal isOpen={isLoginModalOpen} onClose={() => setIsLoginModalOpen(false)} />
     </div>
   );
 }

--- a/src/app/trend-analysis/[category]/[id]/page.tsx
+++ b/src/app/trend-analysis/[category]/[id]/page.tsx
@@ -1,16 +1,19 @@
 'use client';
 
 import { useParams } from 'next/navigation';
+import { useState } from 'react';
 import { CATEGORY_INFO } from '@/constants/mockTrends';
 import TrendLineChart from '@/components/trend-analysis/report-detail/TrendChart';
 import MarketShareDonutChart from '@/components/trend-analysis/report-detail/MarketShareDonutChart';
 import { useFavoritesStore, createTechStackFromNode } from '@/store/favoritesStore';
 import { useSession } from 'next-auth/react';
+import LoginModal from '@/components/LoginModal';
 
 export default function ReportDetailPage() {
     const { category, id } = useParams();
     const { isTechStackFavorite, toggleTechStack } = useFavoritesStore();
     const { data: session } = useSession();
+    const [isLoginModalOpen, setIsLoginModalOpen] = useState(false);
 
     // 1. URL 인코딩 해결 (%20 -> 공백)
     const decodedId = decodeURIComponent(id as string);
@@ -73,7 +76,7 @@ export default function ReportDetailPage() {
             <button 
                 onClick={() => {
                   if (!session) {
-                    alert('로그인이 필요합니다.');
+                    setIsLoginModalOpen(true);
                     return;
                   }
                   if (categoryData && techInfo) {
@@ -122,7 +125,9 @@ export default function ReportDetailPage() {
                 />
             </div>
             </div>
-        </div>
+            </div>
+
+            <LoginModal isOpen={isLoginModalOpen} onClose={() => setIsLoginModalOpen(false)} />
         </main>
     );
 }

--- a/src/app/trend-analysis/[category]/page.tsx
+++ b/src/app/trend-analysis/[category]/page.tsx
@@ -12,6 +12,7 @@ import { CATEGORY_INFO } from '@/constants/mockTrends';
 import { TimeLineDropdown } from '@/components/trend-analysis/TimeLineDropdown';
 import { useFavoritesStore, createTechStackFromNode } from '@/store/favoritesStore';
 import { useSession } from 'next-auth/react';
+import LoginModal from '@/components/LoginModal';
 
 // --- [인터페이스] ---
 interface GraphNode extends d3.SimulationNodeDatum {
@@ -156,6 +157,7 @@ export default function CategoryDetailPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const { data: session } = useSession();
+  const [isLoginModalOpen, setIsLoginModalOpen] = useState(false);
   
   const [selectedNode, setSelectedNode] = useState<GraphNode | null>(null);
   const [activeTab, setActiveTab] = useState<'company' | 'community'>('company');
@@ -411,7 +413,7 @@ export default function CategoryDetailPage() {
                     <button 
                       onClick={() => {
                         if (!session) {
-                          alert('로그인이 필요합니다.');
+                          setIsLoginModalOpen(true);
                           return;
                         }
                         if (currentCategory && selectedNode) {
@@ -446,6 +448,8 @@ export default function CategoryDetailPage() {
           </motion.aside>
         )}
       </AnimatePresence>
+
+      <LoginModal isOpen={isLoginModalOpen} onClose={() => setIsLoginModalOpen(false)} />
     </div>
   );
 }


### PR DESCRIPTION


## 📢 기능 설명

-[] AI 면접 온보딩의 체험 진입과 채용지도/트렌드분석의 즐겨찾기 액션에서 비로그인 상태면 alert 대신 LoginModal을 띄우도록 통일했습니다.

## 연결된 issue

연결된 issue를 자동을 닫기 위해 아래 {40}를 입력해주세요. <br>
close #{40}
<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?